### PR TITLE
Update zaborona-dns-resovler

### DIFF
--- a/config/_zaborona_v2/etc/dnsmasq.d/zaborona-dns-resovler
+++ b/config/_zaborona_v2/etc/dnsmasq.d/zaborona-dns-resovler
@@ -204,6 +204,7 @@ server=/kp.ru/127.0.0.4#5959
 server=/kpfu.ru/127.0.0.4#5959
 server=/krt-club.ru/127.0.0.4#5959
 server=/labirint.ru/127.0.0.4#5959
+server=/lampa32.ru/127.0.0.4#5959
 server=/lenta.ru/127.0.0.4#5959
 server=/lib.ru/127.0.0.4#5959
 server=/lifelink.ru/127.0.0.4#5959


### PR DESCRIPTION
Сайт lampa32.ru на Киевстаре не работает. На других проводных провайдерах - работает